### PR TITLE
Fix: manage multiple instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
-# kth-node-i18n  
+# kth-node-i18n
 
 i18n module for both browser and Node.js.
+
+## Multiple Installed Copies
+
+This package stores language data in module-local state (`messages`). If your dependency tree installs more than one copy of `kth-node-i18n`, each copy has its own `messages` array.
+
+In that situation, one copy may be initialized while another remains empty, which can lead to missing translations.
+
+### Recommendations
+
+- In applications, depend on `kth-node-i18n` directly
+- In shared libraries, prefer `peerDependencies` for `kth-node-i18n`
+- Keep lockfiles deduped so one runtime copy is used
+
+### Troubleshooting
+
+Check how many copies are installed:
+
+```bash
+npm ls kth-node-i18n
+```
+
+If multiple copies are shown, align versions and reinstall dependencies.

--- a/index.js
+++ b/index.js
@@ -49,6 +49,12 @@ function _message(key, overrideLang) {
   // Try to find a language. Use the default (se) if missing.
   const lang = _getLanguageByShortname(language) || _getLanguageByShortname(_DEFAULT_LANG)
 
+  // In some setups multiple instances of this package can be loaded,
+  // and the current instance may not have been populated with messages.
+  if (!lang || !lang.messages) {
+    return 'KEY ' + key + ' FOR LANGUAGE ' + language + ' DOES NOT EXIST'
+  }
+
   // Make sure we see if a key is missing
   if (lang.messages[key] === undefined) {
     return 'KEY ' + key + ' FOR LANGUAGE ' + lang.longNameEn + ' DOES NOT EXIST'

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const messages = []
 const _DEFAULT_LANG = 'sv'
+let hasWarnedUninitializedMessages = false
 
 /**
  * Fetches a language by its short name.
@@ -52,6 +53,13 @@ function _message(key, overrideLang) {
   // In some setups multiple instances of this package can be loaded,
   // and the current instance may not have been populated with messages.
   if (!lang || !lang.messages) {
+    if (!hasWarnedUninitializedMessages) {
+      hasWarnedUninitializedMessages = true
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[kth-node-i18n] No language messages are loaded in this module instance. This can happen when multiple copies of kth-node-i18n are installed. Check your dependency tree and run "npm ls kth-node-i18n".'
+      )
+    }
     return 'KEY ' + key + ' FOR LANGUAGE ' + language + ' DOES NOT EXIST'
   }
 

--- a/index.test.js
+++ b/index.test.js
@@ -19,6 +19,14 @@ i18n.messages.push(
   }
 )
 describe('Testing i18n', () => {
+  it('should return a fallback message when no languages are configured', () => {
+    jest.isolateModules(() => {
+      const isolatedI18n = require('./index')
+      const msg = isolatedI18n.message('message', 'en')
+      expect(msg).toBe('KEY message FOR LANGUAGE en DOES NOT EXIST')
+    })
+  })
+
   it('should get a message by language', () => {
     const msg = i18n.message('message', 'en')
     expect(msg).toBe('Message')

--- a/index.test.js
+++ b/index.test.js
@@ -19,12 +19,29 @@ i18n.messages.push(
   }
 )
 describe('Testing i18n', () => {
+  it('should warn once when no languages are configured', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    jest.isolateModules(() => {
+      const isolatedI18n = require('./index')
+      isolatedI18n.message('message', 'en')
+      isolatedI18n.message('message', 'en')
+    })
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    warnSpy.mockRestore()
+  })
+
   it('should return a fallback message when no languages are configured', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
     jest.isolateModules(() => {
       const isolatedI18n = require('./index')
       const msg = isolatedI18n.message('message', 'en')
       expect(msg).toBe('KEY message FOR LANGUAGE en DOES NOT EXIST')
     })
+
+    warnSpy.mockRestore()
   })
 
   it('should get a message by language', () => {


### PR DESCRIPTION
This package stores language data in module-local state (`messages`). If the dependency tree installs more than one copy of `kth-node-i18n`, each copy has its own `messages` array.

In that situation, one copy may be initialized while another remains empty, which can lead to missing translations.
